### PR TITLE
better fix for DB/web init

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 
 services:
   web:
+    #build: .
     image: ghcr.io/aaron9589/shipper-driven-traffic-simulator:latest
     ports:
       - "8980:80" # Change the port on the LEFT of the colon to the desired port you want to advertise the service on your PC.
@@ -30,10 +31,12 @@ services:
       - MYSQL_DATABASE=sts_db3
       - MYSQL_USER=sts_user
       - MYSQL_PASSWORD=sts_password # ensure this matches the MYSQL_DATABASE variable you set earlier.
+
     # If you want to persist your database somewhere outside of the container (you should) uncomment this line,
     # and change the path on the left hand side of the colon.
     #volumes:
       #- /volume1/docker/sts/db:/var/lib/mysql
+
     healthcheck:
       interval: 10s
       retries: 3

--- a/start.sh
+++ b/start.sh
@@ -6,10 +6,12 @@ if [ "$PROVISION_DATABASE" = "1" ]; then
     if [ ! -f /opt/sql.initialized ]; then
 
         # Execute the SQL script on the newly created database with authentication
-        mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < /var/www/html/sts/create_sts_db3.sql
-
-        # Create a marker to indicate that database initialization is completed
-        touch /opt/sql.initialized
+        if mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < /var/www/html/sts/create_sts_db3.sql; then
+            # Create a marker to indicate that database initialization is completed
+            touch /opt/sql.initialized
+        else
+            echo "MySQL command failed. Database initialization aborted."
+        fi
 
     fi
 fi


### PR DESCRIPTION
better fix for the mariadb/sts startup issue.

When MariaDB starts without existing data, it takes a while to initialise. STS was initialising in parallel and most of the time, would fail its init script as a result.

- Added a healthcheck for MariaDB and a dependson clause so the DB will fully intialise before sts starts
- added a catch in the STS startup script so if the init does fail, it will re-run on startup.