### PR TITLE
fix: correct destination shown for non-revenue cars in station report pickup summary

### DIFF
--- a/sts/display_station_report.php
+++ b/sts/display_station_report.php
@@ -122,15 +122,15 @@ if (isset($_GET['generate_report'])) {
             </thead>
             <tbody>
               <?php foreach ($job_rows as $r):
-                if ($r['status'] == "Ordered") {
+                if (substr($r['waybill_number'], 4, 1) == "E") {
+                  $dest       = htmlspecialchars($r['dest_station']) . '<br/>' . htmlspecialchars($r['dest_code']);
+                  $dest_style = set_colors($dbc, $r['dest_code']);
+                } elseif ($r['status'] == "Ordered") {
                   $dest       = htmlspecialchars($r['loading_station']) . '<br/>' . htmlspecialchars($r['loading_location']);
                   $dest_style = set_colors($dbc, $r['loading_location']);
                 } elseif (in_array($r['status'], ["Loading", "Loaded", "Unloading"])) {
                   $dest       = htmlspecialchars($r['unloading_station']) . '<br/>' . htmlspecialchars($r['unloading_location']);
                   $dest_style = set_colors($dbc, $r['unloading_location']);
-                } elseif (substr($r['waybill_number'], 4, 1) == "E") {
-                  $dest       = htmlspecialchars($r['dest_station']) . '<br/>' . htmlspecialchars($r['dest_code']);
-                  $dest_style = set_colors($dbc, $r['dest_code']);
                 } else {
                   $dest = ''; $dest_style = '';
                 }
@@ -341,15 +341,15 @@ if (isset($_GET['generate_report'])) {
             </thead>
             <tbody>
               <?php foreach ($job_rows as $r):
-                if ($r['status'] == "Ordered") {
+                if (substr($r['waybill_number'], 4, 1) == "E") {
+                  $dest       = htmlspecialchars($r['dest_station']) . '<br/>' . htmlspecialchars($r['dest_code']);
+                  $dest_style = set_colors($dbc, $r['dest_code']);
+                } elseif ($r['status'] == "Ordered") {
                   $dest       = htmlspecialchars($r['loading_station']) . '<br/>' . htmlspecialchars($r['loading_location']);
                   $dest_style = set_colors($dbc, $r['loading_location']);
                 } elseif (in_array($r['status'], ["Loading", "Loaded", "Unloading"])) {
                   $dest       = htmlspecialchars($r['unloading_station']) . '<br/>' . htmlspecialchars($r['unloading_location']);
                   $dest_style = set_colors($dbc, $r['unloading_location']);
-                } elseif (substr($r['waybill_number'], 4, 1) == "E") {
-                  $dest       = htmlspecialchars($r['dest_station']) . '<br/>' . htmlspecialchars($r['dest_code']);
-                  $dest_style = set_colors($dbc, $r['dest_code']);
                 } else {
                   $dest = ''; $dest_style = '';
                 }


### PR DESCRIPTION
## Bug

E-waybill cars (non-revenue repositioning) have a location ID stored in `car_orders.shipment` rather than a shipment ID. When that location ID coincidentally matched an existing `shipments` row, the status-first branch logic in the pickup summary would display the wrong shipment's loading/unloading station as the destination.

**Affected cars:** 82108D, 18204E, 82116Q — all showed "Shoalhaven Starches Intermodal Sidings" instead of the correct "Clyde Yard" destination.

## Root Cause

Regression introduced in `4e82b17` (feat: improve printout readability and add Handled By column to pickup summary). The `"E"\ waybill check was placed as the last `elseif` branch, so any non-revenue car with status `Ordered` would fall through to the status-based branch first.

## Fix

Move the E-waybill check to the **top** of the `if/elseif` chain in both pickup summary sections (single-station and all-stations), so non-revenue cars always resolve their destination from the dedicated `sql2` lookup.