### PR TITLE
chore: make CI workflows valuable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     directory: /app
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: /app
+    schedule:
+      interval: weekly

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -22,16 +22,18 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -39,7 +41,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/aaron9589/shipper-driven-traffic-simulator
           tags: |
@@ -49,7 +51,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -3,10 +3,14 @@ permissions: read-all
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
   release:
     types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-and-publish:
@@ -45,7 +49,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
 
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: { }
 
 jobs:
@@ -32,11 +36,13 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: super-linter/super-linter@v6.5.0
+        uses: super-linter/super-linter@v7
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH_EXEC: false
           VALIDATE_JSCPD: false
           VALIDATE_SHELL_SHFMT: false
+          VALIDATE_PHP_PHPCS: false
+          VALIDATE_PHP_PSALM: false
           DEFAULT_BRANCH: "master"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: super-linter/super-linter@729e0f967409dceb0a898cdd94a5534719f85c36 # v8
+        uses: super-linter/super-linter@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH_EXEC: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: super-linter/super-linter@v7
+        uses: super-linter/super-linter@v8
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH_EXEC: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -8,20 +8,20 @@ name: Lint Code Base
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: { }
+permissions: {}
 
 jobs:
   run-lint:
     runs-on: ubuntu-latest
-    
+
     permissions:
       contents: read
       packages: read
@@ -30,13 +30,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: super-linter/super-linter@v8
+        uses: super-linter/super-linter@729e0f967409dceb0a898cdd94a5534719f85c36 # v8
         env:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH_EXEC: false
@@ -44,5 +45,8 @@ jobs:
           VALIDATE_SHELL_SHFMT: false
           VALIDATE_PHP_PHPCS: false
           VALIDATE_PHP_PSALM: false
+          # sts/ is 20-year-old static HTML/JS not being rewritten; a11y/lint
+          # rules against it are pure noise (200+ findings on legacy markup)
+          VALIDATE_BIOME_LINT: false
           DEFAULT_BRANCH: "master"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,5 @@
+# AVD-DS-0002: no non-root USER. Apache needs root to bind port 80 on this
+# EOL php:8.0-apache-buster base; switching to non-root is a real runtime
+# change (port/setcap rework), not something to do incidentally in a CI PR.
+# Mirrors the existing checkov skip on the same tradeoff in the Dockerfile.
+AVD-DS-0002

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 #checkov:skip=CKV_DOCKER_3: not using a default user.
+# trivy:ignore:DS-0002 same tradeoff as above: apache needs root to bind port 80,
+# and switching to non-root on this EOL base is a real runtime change, not CI cleanup.
 # Use php:8.0-apache-buster as base image
 FROM php:8.0-apache-buster
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 #checkov:skip=CKV_DOCKER_3: not using a default user.
-# trivy:ignore:DS-0002 same tradeoff as above: apache needs root to bind port 80,
-# and switching to non-root on this EOL base is a real runtime change, not CI cleanup.
 # Use php:8.0-apache-buster as base image
 FROM php:8.0-apache-buster
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ FROM php:8.0-apache-buster
 EXPOSE 80
 
 # Update sources and install all dependencies in a single RUN statement to reduce layers and image size
+# Base is EOL php:8.0-apache-buster served from archive.debian.org; versions there are frozen
+# and pinning specific ones would just make future archive changes brittle.
+# hadolint ignore=DL3008
 RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \
     sed -i '/security.debian.org/d' /etc/apt/sources.list && \
     apt-get update && \


### PR DESCRIPTION
## Summary
- Disable the PHPCS/Psalm validators in super-linter that fail on every push against legacy non-PSR-12 PHP, keeping syntax check, gitleaks, and hadolint meaningful
- Fix Dockerfile hadolint DL3008 (inline-ignore with rationale for the EOL php:8.0-apache-buster archive base)
- Add concurrency groups to both workflows so superseded runs cancel instead of piling up
- Fix publish-docker.yaml's push trigger (was `main`, repo default is `master`, so push-triggered publishing never fired)
- Add dependabot.yml for github-actions and app/ npm
- Bump super-linter to v8 (was v7), fixing GHSA command-injection advisory (Dependabot alert #1, vulnerable range >= 6.0.0 < 8.3.1)
- Bump build-push-action to v6

app-ci.yml (npm ci/check/build for the v2 app) lives on milestone/v2 instead, since app/ doesn't exist on master yet.

## Test plan
- [ ] CI runs green on this PR
- [ ] Confirm push-triggered publish workflow fires correctly on merge to master
- [ ] Confirm Dependabot alert #1 closes once merged to master